### PR TITLE
Flip order of NSLocation Usage Description checks

### DIFF
--- a/src/Plugin.Permissions.iOSUnified/PermissionsImplementation.cs
+++ b/src/Plugin.Permissions.iOSUnified/PermissionsImplementation.cs
@@ -278,10 +278,10 @@ namespace Plugin.Permissions
 
 
             var info = NSBundle.MainBundle.InfoDictionary;
-            if (info.ContainsKey(new NSString("NSLocationWhenInUseUsageDescription")))
-                locationManager.RequestWhenInUseAuthorization();
-            else if (info.ContainsKey(new NSString("NSLocationAlwaysUsageDescription")))
+            if (info.ContainsKey(new NSString("NSLocationAlwaysUsageDescription")))
                 locationManager.RequestAlwaysAuthorization();
+            else if (info.ContainsKey(new NSString("NSLocationWhenInUseUsageDescription")))
+                locationManager.RequestWhenInUseAuthorization();
             else
                 throw new UnauthorizedAccessException("On iOS 8.0 and higher you must set either NSLocationWhenInUseUsageDescription or NSLocationAlwaysUsageDescription in your Info.plist file to enable Authorization Requests for Location updates!");
 


### PR DESCRIPTION
Starting in iOS10, showing the user's location on a map requires the NSLocationWhenInUseDescription, even if NSLocationAlwaysUsageDescription is already present in info.plist. There are probably other location features with similar problems. 

It is better to check for the Always Usage description first, because that will enable all location features in an app that contains both descriptions, whereas requesting and enabling on When In Use will only provide a subset. This is especially important because iOS will only present the request dialog the first time an authorization request is made after the app is installed.

Changes Proposed in this pull request:
- Check for NSLocationAlwaysUsageDescription before NSLocationWhenInUseDescription in RequestLocationPermission()
